### PR TITLE
Update yaml requirement to 2.8|3.0 so it is not in conflict with robmorgan/phinx

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"require": {
 		"cakephp/cakephp": "~3.0",
 		"cakephp/plugin-installer": "*",
-		"symfony/yaml": "2.6.*@dev"
+        "symfony/yaml": "~2.8|~3.0"
 		},
 		"authors": [
 		{

--- a/src/Configure/Engine/YamlConfig.php
+++ b/src/Configure/Engine/YamlConfig.php
@@ -13,6 +13,12 @@ class YamlConfig implements ConfigEngineInterface
 
     protected $_extension = '.yml';
 
+    /**
+     * Method: __construct
+     *
+     * @param mixed $path Path
+     * @return void
+     */
     public function __construct($path = null)
     {
         if ($path === null) {
@@ -22,13 +28,14 @@ class YamlConfig implements ConfigEngineInterface
     }
 
     /**
-     * @param string $key
+     * @param string $key Key
      * @return array
      */
     public function read($key)
     {
         $file = $this->_getFilePath($key, true);
-        $config = Yaml::parse($file);
+        $input = file_get_contents($file);
+        $config = Yaml::parse($input);
         if (is_array($config)) {
             return $config;
         } else {
@@ -36,6 +43,13 @@ class YamlConfig implements ConfigEngineInterface
         }
     }
 
+    /**
+     * Method: dump
+     *
+     * @param mixed $key Key
+     * @param array $data Data
+     * @return void
+     */
     public function dump($key, array $data)
     {
         // Code to dump data to file


### PR DESCRIPTION
When I tried to install your plugin with composer it gave me conclusion: remove symfony/yaml v3.0.1 which is required by robmorgan/phinx, the lib used by cakephp. I think you need to update your composer.json file with new version of yaml.

With Yaml::parse you now need to file_get_contents first as parameter should be string, not file. I have also added some doc to pass cake code sniffer